### PR TITLE
Update sleep dependency to fix failing install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/Rob--W/node-xvfb.git"
   },
   "dependencies": {
-    "sleep": "2.0.x"
+    "sleep": "3.0.x"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
In version 2.0.x of `sleep`, it depended on the package `nan` using a wildcard.
Recently, `nan` has completely changed their API, which results in `sleep` not working anymore. When running `npm install` this results in

```
CXX(target) Release/obj.target/node_sleep/sleep.o
../sleep.cc:36:3: error: use of undeclared identifier 'NanScope'
  NanScope();
(..)
```

This issue has been fixed in version 3.0.0 of `sleep` (see ErikDubbelboer/node-sleep#31).
